### PR TITLE
Implement inversion state management

### DIFF
--- a/JUCE_UPLOAD/Source/MainComponent.h
+++ b/JUCE_UPLOAD/Source/MainComponent.h
@@ -49,6 +49,9 @@ private:
     VerticalFaderComponent verticalFader;
     SettingsPanelXLComponent settingsPanel;
 
+    // ValueTree to store persistent state
+    juce::ValueTree state { "AppState" };
+
     // Custom LookAndFeel for plus/minus buttons
     class ButtonLookAndFeel : public juce::LookAndFeel_V4
     {
@@ -88,6 +91,12 @@ private:
     const juce::String whiteKeyNotes[7] = {"C", "D", "E", "F", "G", "A", "B"};
     // Using nullptrs for spacing in black key array based on PianoXL.tsx structure
     const juce::String blackKeyNotes[6] = {"C#", "D#", "", "F#", "G#", "A#"}; // "" for placeholder
+
+    // Persistence helpers
+    void loadState();
+    void saveState();
+
+    juce::File getStateFile() const;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainComponent)
 }; 

--- a/JUCE_UPLOAD/Source/SettingsPanelXLComponent.cpp
+++ b/JUCE_UPLOAD/Source/SettingsPanelXLComponent.cpp
@@ -209,6 +209,11 @@ void SettingsPanelXLComponent::toggleSelection(const juce::String& control)
     std::cout << "Selected control: " << (selectedControl.isEmpty() ? "none" : selectedControl) << std::endl;
 }
 
+void SettingsPanelXLComponent::setSelectedControl(const juce::String& control)
+{
+    toggleSelection(control);
+}
+
 void SettingsPanelXLComponent::setInversionValue(int newValue)
 {
     if (currentInversionValue != newValue)


### PR DESCRIPTION
## Summary
- add ValueTree state to store inversion value and selection
- persist settings to an XML file
- update plus/minus controls to modify state
- wire SettingsPanel selection to ValueTree

## Testing
- `cmake ..` *(fails: JUCE dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_686745bc49cc8327a6dd44cdb8fb447b